### PR TITLE
Fix: input device plugin structure

### DIFF
--- a/march_rqt_input_device/CMakeLists.txt
+++ b/march_rqt_input_device/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(march_rqt_input_device)
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS march_shared_resources std_msgs)
 
 catkin_python_setup()
-catkin_package()
+catkin_package(CATKIN_DEPENDS march_shared_resources std_msgs)
 
 install(FILES plugin.xml
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}

--- a/march_rqt_input_device/package.xml
+++ b/march_rqt_input_device/package.xml
@@ -9,6 +9,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>std_msgs</depend>
+  <depend>march_shared_resources</depend>
+
   <exec_depend>rospy</exec_depend>
   <exec_depend>rqt_gui</exec_depend>
   <exec_depend>rqt_gui_py</exec_depend>

--- a/march_rqt_input_device/plugin.xml
+++ b/march_rqt_input_device/plugin.xml
@@ -1,5 +1,5 @@
 <library path="src">
-    <class name="InputDevicePlugin" type="march_rqt_input_device.input_device_view.InputDevicePlugin" base_class_type="rqt_gui_py::Plugin">
+    <class name="InputDevicePlugin" type="march_rqt_input_device.input_device_plugin.InputDevicePlugin" base_class_type="rqt_gui_py::Plugin">
         <description>
             An example Python GUI plugin to create a great user interface.
         </description>

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -6,9 +6,9 @@ from march_shared_resources.msg import Error, GaitInstruction
 
 class InputDeviceController(object):
     def __init__(self):
-        self.instruction_gait_pub = rospy.Publisher('/march/input_device/instruction', GaitInstruction, queue_size=10)
+        self._instruction_gait_pub = rospy.Publisher('/march/input_device/instruction', GaitInstruction, queue_size=10)
+        self._error_pub = rospy.Publisher('/march/error', Error, queue_size=10)
 
-        self.error_pub = rospy.Publisher('/march/error', Error, queue_size=10)
         self._ping = rospy.get_param('~ping_safety_node', True)
 
         if self._ping:
@@ -16,9 +16,12 @@ class InputDeviceController(object):
             period = rospy.Duration().from_sec(0.2)
             self._alive_timer = rospy.Timer(period, self._timer_callback)
 
-    def shutdown_plugin(self):
+    def __del__(self):
+        self._instruction_gait_pub.unregister()
+        self._error_pub.unregister()
         if self._ping:
             self._alive_timer.shutdown()
+            self._alive_timer.join()
             self._alive_pub.unregister()
 
     def _timer_callback(self, event):
@@ -26,35 +29,35 @@ class InputDeviceController(object):
 
     def publish_increment_step_size(self):
         rospy.logdebug('Mock Input Device published step size increment')
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.INCREMENT_STEP_SIZE, ''))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.INCREMENT_STEP_SIZE, ''))
 
     def publish_decrement_step_size(self):
         rospy.logdebug('Mock Input Device published step size decrement')
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.DECREMENT_STEP_SIZE, ''))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.DECREMENT_STEP_SIZE, ''))
 
     def publish_gait(self, string):
         rospy.logdebug('Mock Input Device published gait: ' + string)
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.GAIT, string))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.GAIT, string))
 
     def publish_stop(self):
         rospy.logdebug('Mock Input Device published stop')
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.STOP, ''))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.STOP, ''))
 
     def publish_continue(self):
         rospy.logdebug('Mock Input Device published continue')
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.CONTINUE, ''))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.CONTINUE, ''))
 
     def publish_pause(self):
         rospy.logdebug('Mock Input Device published pause')
-        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                                          GaitInstruction.PAUSE, ''))
+        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                           GaitInstruction.PAUSE, ''))
 
     def publish_error(self):
         rospy.logdebug('Mock Input Device published error')
-        self.error_pub.publish(Error(std_msgs.msg.Header(stamp=rospy.Time.now()),
-                                     'Fake error thrown by the develop input device.', Error.FATAL))
+        self._error_pub.publish(Error(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                      'Fake error thrown by the develop input device.', Error.FATAL))

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -13,7 +13,8 @@ class InputDeviceController(object):
 
         if self._ping:
             self._alive_pub = rospy.Publisher('/march/input_device/alive', std_msgs.msg.Time, queue_size=10)
-            self._alive_timer = rospy.Timer(rospy.Duration(0.05), self._timer_callback)
+            period = rospy.Duration().from_sec(0.2)
+            self._alive_timer = rospy.Timer(period, self._timer_callback)
 
     def shutdown_plugin(self):
         if self._ping:

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -5,11 +5,11 @@ from march_shared_resources.msg import Error, GaitInstruction
 
 
 class InputDeviceController(object):
-    def __init__(self):
+    def __init__(self, ping):
         self._instruction_gait_pub = rospy.Publisher('/march/input_device/instruction', GaitInstruction, queue_size=10)
         self._error_pub = rospy.Publisher('/march/error', Error, queue_size=10)
 
-        self._ping = rospy.get_param('~ping_safety_node', True)
+        self._ping = ping
 
         if self._ping:
             self._alive_pub = rospy.Publisher('/march/input_device/alive', std_msgs.msg.Time, queue_size=10)

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_plugin.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_plugin.py
@@ -1,0 +1,26 @@
+import os
+
+from qt_gui.plugin import Plugin
+import rospkg
+import rospy
+
+from .input_device_controller import InputDeviceController
+from .input_device_view import InputDeviceView
+
+
+class InputDevicePlugin(Plugin):
+    def __init__(self, context):
+        super(InputDevicePlugin, self).__init__(context)
+
+        self.setObjectName('InputDevicePlugin')
+
+        ping = rospy.get_param('~ping_safety_node', True)
+        ui_file = os.path.join(rospkg.RosPack().get_path('march_rqt_input_device'), 'resource', 'input_device.ui')
+
+        self._controller = InputDeviceController(ping)
+        self._widget = InputDeviceView(ui_file, self._controller)
+        context.add_widget(self._widget)
+
+        # Show _widget.windowTitle on left-top of each plugin (when it's set in _widget). (useful for multiple windows)
+        if context.serial_number() > 1:
+            self._widget.setWindowTitle('{0} ({1})'.format(self._widget.windowTitle(), context.serial_number()))

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -1,229 +1,215 @@
 import os
 
-
 from python_qt_binding import loadUi
 from python_qt_binding.QtCore import QSize
 from python_qt_binding.QtWidgets import QGridLayout
 from python_qt_binding.QtWidgets import QPushButton
 from python_qt_binding.QtWidgets import QWidget
-from qt_gui.plugin import Plugin
 import rospkg
 
-from march_rqt_input_device.input_device_controller import InputDeviceController
 
+class InputDeviceView(QWidget):
+    def __init__(self, ui_file, controller):
+        """
+        Initializes the view with a UI file and controller.
 
-class InputDevicePlugin(Plugin):
-    def __init__(self, context):
-        super(InputDevicePlugin, self).__init__(context)
-        self.controller = InputDeviceController()
-
-        # region initialising the widget
-        self.setObjectName('InputDevicePlugin')
-
-        # Create QWidget
-        self._widget = QWidget()
-
-        # Get path to UI file which should be in the 'resource' folder of this package
-        ui_file = os.path.join(rospkg.RosPack().get_path('march_rqt_input_device'), 'resource', 'input_device.ui')
+        :type ui_file: str
+        :param ui_file: path to a Qt UI file
+        :type controller: InputDeviceController
+        :param controller: input device controller for sending ROS messages
+        """
+        super(InputDeviceView, self).__init__()
+        self._controller = controller
 
         # Extend the widget with all attributes and children from UI file
-        loadUi(ui_file, self._widget)
-
-        # Give QObjects reasonable names
-        self._widget.setObjectName('Input Device')
-
-        # Show _widget.windowTitle on left-top of each plugin (when it's set in _widget). (useful for multiple windows)
-        if context.serial_number() > 1:
-            self._widget.setWindowTitle('{0} ({1})'.format(self._widget.windowTitle(), context.serial_number()))
-
-        # Add widget to the user interface
-        context.add_widget(self._widget)
+        loadUi(ui_file, self)
 
         # Create buttons here
         rocker_switch_increment = \
             self.create_button('rocker_switch_up', image_path='/rocker_switch_up.png',
-                               callback=lambda: self.controller.publish_increment_step_size())
+                               callback=lambda: self._controller.publish_increment_step_size())
 
         rocker_switch_decrement = \
             self.create_button('rocker_switch_down', image_path='/rocker_switch_down.png',
-                               callback=lambda: self.controller.publish_decrement_step_size())
+                               callback=lambda: self._controller.publish_decrement_step_size())
 
         home_sit = \
             self.create_button('home_sit', image_path='/home_sit.png',
-                               callback=lambda: self.controller.publish_gait('home_sit'))
+                               callback=lambda: self._controller.publish_gait('home_sit'))
 
         home_stand = \
             self.create_button('home_stand', image_path='/home_stand.png',
-                               callback=lambda: self.controller.publish_gait('home_stand'))
+                               callback=lambda: self._controller.publish_gait('home_stand'))
 
         gait_sit = \
             self.create_button('gait_sit', image_path='/gait_sit.png',
-                               callback=lambda: self.controller.publish_gait('gait_sit'))
+                               callback=lambda: self._controller.publish_gait('gait_sit'))
 
         gait_walk = \
             self.create_button('gait_walk', image_path='/gait_walk.png',
-                               callback=lambda: self.controller.publish_gait('gait_walk'))
+                               callback=lambda: self._controller.publish_gait('gait_walk'))
 
         gait_walk_small = \
             self.create_button('gait_walk_small', image_path='/gait_walk_small.png',
-                               callback=lambda: self.controller.publish_gait('gait_walk_small'))
+                               callback=lambda: self._controller.publish_gait('gait_walk_small'))
 
         gait_walk_large = \
             self.create_button('gait_walk_large', image_path='/gait_walk_large.png',
-                               callback=lambda: self.controller.publish_gait('gait_walk_large'))
+                               callback=lambda: self._controller.publish_gait('gait_walk_large'))
 
         gait_single_step_small = \
             self.create_button('gait_single_step_small', image_path='/gait_single_step_small.png',
-                               callback=lambda: self.controller.publish_gait('gait_single_step_small'))
+                               callback=lambda: self._controller.publish_gait('gait_single_step_small'))
 
         gait_single_step_normal = \
             self.create_button('gait_single_step_normal', image_path='/gait_single_step_medium.png',
-                               callback=lambda: self.controller.publish_gait('gait_single_step_normal'))
+                               callback=lambda: self._controller.publish_gait('gait_single_step_normal'))
 
         gait_side_step_left = \
             self.create_button('gait_side_step_left', image_path='/gait_side_step_left.png',
-                               callback=lambda: self.controller.publish_gait('gait_side_step_left'))
+                               callback=lambda: self._controller.publish_gait('gait_side_step_left'))
 
         gait_side_step_right = \
             self.create_button('gait_side_step_right', image_path='/gait_side_step_right.png',
-                               callback=lambda: self.controller.publish_gait('gait_side_step_right'))
+                               callback=lambda: self._controller.publish_gait('gait_side_step_right'))
 
         gait_side_step_left_small = \
             self.create_button('gait_side_step_left_small',
-                               callback=lambda: self.controller.publish_gait('gait_side_step_left_small'))
+                               callback=lambda: self._controller.publish_gait('gait_side_step_left_small'))
 
         gait_side_step_right_small = \
             self.create_button('gait_side_step_right_small',
-                               callback=lambda: self.controller.publish_gait('gait_side_step_right_small'))
+                               callback=lambda: self._controller.publish_gait('gait_side_step_right_small'))
 
         gait_stand = \
             self.create_button('gait_stand', image_path='/gait_stand.png',
-                               callback=lambda: self.controller.publish_gait('gait_stand'))
+                               callback=lambda: self._controller.publish_gait('gait_stand'))
 
         gait_sofa_stand = \
             self.create_button('gait_sofa_stand', image_path='/gait_sofa_stand.png',
-                               callback=lambda: self.controller.publish_gait('gait_sofa_stand'))
+                               callback=lambda: self._controller.publish_gait('gait_sofa_stand'))
 
         gait_sofa_sit = \
             self.create_button('gait_sofa_sit', image_path='/gait_sofa_sit.png',
-                               callback=lambda: self.controller.publish_gait('gait_sofa_sit'))
+                               callback=lambda: self._controller.publish_gait('gait_sofa_sit'))
 
         gait_stairs_up = \
             self.create_button('gait_stairs_up', image_path='/gait_stairs_up.png',
-                               callback=lambda: self.controller.publish_gait('gait_stairs_up'))
+                               callback=lambda: self._controller.publish_gait('gait_stairs_up'))
 
         gait_stairs_down = \
             self.create_button('gait_stairs_down', image_path='/gait_stairs_down.png',
-                               callback=lambda: self.controller.publish_gait('gait_stairs_down'))
+                               callback=lambda: self._controller.publish_gait('gait_stairs_down'))
 
         gait_stairs_up_single_step = \
             self.create_button('gait_stairs_up_single_step', image_path='/gait_stairs_up_single_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_stairs_up_single_step'))
+                               callback=lambda: self._controller.publish_gait('gait_stairs_up_single_step'))
 
         gait_stairs_down_single_step = \
             self.create_button('gait_stairs_down_single_step', image_path='/gait_stairs_down_single_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_stairs_down_single_step'))
+                               callback=lambda: self._controller.publish_gait('gait_stairs_down_single_step'))
 
         gait_rough_terrain_high_step = \
             self.create_button('gait_rough_terrain_high_step', image_path='/gait_rough_terrain_high_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_rough_terrain_high_step'))
+                               callback=lambda: self._controller.publish_gait('gait_rough_terrain_high_step'))
 
         gait_rough_terrain_middle_steps = \
             self.create_button('gait_rough_terrain_middle_steps',
-                               callback=lambda: self.controller.publish_gait('gait_rough_terrain_middle_steps'))
+                               callback=lambda: self._controller.publish_gait('gait_rough_terrain_middle_steps'))
 
         gait_rough_terrain_first_middle_step = \
             self.create_button('gait_rough_terrain_first_middle_step',
                                image_path='/gait_rough_terrain_first_middle_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_rough_terrain_first_middle_step'))
+                               callback=lambda: self._controller.publish_gait('gait_rough_terrain_first_middle_step'))
 
         gait_rough_terrain_second_middle_step = \
             self.create_button('gait_rough_terrain_second_middle_step',
                                image_path='/gait_rough_terrain_second_middle_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_rough_terrain_second_middle_step'))
+                               callback=lambda: self._controller.publish_gait('gait_rough_terrain_second_middle_step'))
 
         gait_rough_terrain_third_middle_step = \
             self.create_button('gait_rough_terrain_third_middle_step',
                                image_path='/gait_rough_terrain_third_middle_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_rough_terrain_third_middle_step'))
+                               callback=lambda: self._controller.publish_gait('gait_rough_terrain_third_middle_step'))
 
         gait_ramp_door_slope_up = \
             self.create_button('gait_ramp_door_slope_up', image_path='/gait_ramp_door_slope_up.png',
-                               callback=lambda: self.controller.publish_gait('gait_ramp_door_slope_up'))
+                               callback=lambda: self._controller.publish_gait('gait_ramp_door_slope_up'))
 
         gait_ramp_door_slope_down = \
             self.create_button('gait_ramp_door_slope_down', image_path='/gait_ramp_door_slope_down.png',
-                               callback=lambda: self.controller.publish_gait('gait_ramp_door_slope_down'))
+                               callback=lambda: self._controller.publish_gait('gait_ramp_door_slope_down'))
 
         gait_ramp_door_last_step = \
             self.create_button('gait_ramp_door_last_step', image_path='/gait_ramp_door_last_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_ramp_door_last_step'))
+                               callback=lambda: self._controller.publish_gait('gait_ramp_door_last_step'))
 
         gait_tilted_path_left_straight_start = \
             self.create_button('gait_tilted_path_left_straight_start',
                                image_path='/gait_tilted_path_left_straight_start.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_left_straight_start'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_left_straight_start'))
 
         gait_tilted_path_left_single_step = \
             self.create_button('gait_tilted_path_left_single_step',
                                image_path='/gait_tilted_path_left_single_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_left_single_step'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_left_single_step'))
 
         gait_tilted_path_left_straight_end = \
             self.create_button('gait_tilted_path_left_straight_end',
                                image_path='/gait_tilted_path_left_straight_end.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_left_straight_end'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_left_straight_end'))
 
         gait_tilted_path_left_flexed_knee_step = \
             self.create_button('gait_tilted_path_left_flexed_knee_step',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_left_flexed_knee_step'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_left_flexed_knee_step'))
 
         gait_tilted_path_right_straight_start = \
             self.create_button('gait_tilted_path_right_straight_start',
                                image_path='/gait_tilted_path_right_straight_start.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_right_straight_start'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_right_straight_start'))
 
         gait_tilted_path_right_single_step = \
             self.create_button('gait_tilted_path_right_single_step',
                                image_path='/gait_tilted_path_right_single_step.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_right_single_step'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_right_single_step'))
 
         gait_tilted_path_right_straight_end = \
             self.create_button('gait_tilted_path_right_straight_end',
                                image_path='/gait_tilted_path_right_straight_end.png',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_right_straight_end'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_right_straight_end'))
 
         gait_tilted_path_right_flexed_knee_step = \
             self.create_button('gait_tilted_path_right_flexed_knee_step',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_right_flexed_knee_step'))
+                               callback=lambda: self._controller.publish_gait(
+                                   'gait_tilted_path_right_flexed_knee_step'))
 
         gait_tilted_path_first_start = \
             self.create_button('gait_tilted_path_first_start',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_first_start'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_first_start'))
 
         gait_tilted_path_second_start = \
             self.create_button('gait_tilted_path_second_start',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_second_start'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_second_start'))
 
         gait_tilted_path_first_end = \
             self.create_button('gait_tilted_path_first_end',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_first_end'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_first_end'))
 
         gait_tilted_path_second_end = \
             self.create_button('gait_tilted_path_second_end',
-                               callback=lambda: self.controller.publish_gait('gait_tilted_path_second_end'))
+                               callback=lambda: self._controller.publish_gait('gait_tilted_path_second_end'))
 
         stop_button = self.create_button('gait_stop', image_path='/stop.png',
-                                         callback=lambda: self.controller.publish_stop())
+                                         callback=lambda: self._controller.publish_stop())
 
         pause_button = self.create_button('gait_pause', image_path='/pause.png',
-                                          callback=lambda: self.controller.publish_pause())
+                                          callback=lambda: self._controller.publish_pause())
 
         continue_button = self.create_button('gait_continue', image_path='/continue.png',
-                                             callback=lambda: self.controller.publish_continue())
+                                             callback=lambda: self._controller.publish_continue())
 
         error_button = self.create_button('error', image_path='/error.png',
-                                          callback=lambda: self.controller.publish_error())
+                                          callback=lambda: self._controller.publish_error())
 
         # The button layout.
         # Position in the array determines position on screen.
@@ -259,11 +245,11 @@ class InputDevicePlugin(Plugin):
         qt_layout = self.create_layout(march_button_layout)
 
         # Apply the qt_layout to the top level widget.
-        self._widget.frame.findChild(QWidget, 'content').setLayout(qt_layout)
+        self.frame.findChild(QWidget, 'content').setLayout(qt_layout)
 
         # Make the frame as tight as possible with spacing between the buttons.
         qt_layout.setSpacing(15)
-        self._widget.frame.findChild(QWidget, 'content').adjustSize()
+        self.frame.findChild(QWidget, 'content').adjustSize()
 
     @staticmethod
     def create_button(text, callback=None, image_path=None, size=(125, 150), visible=True, color_code='#1F1E24'):


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

## Description
While working on PM-392, I noticed that the input device had the Qt Plugin and Widget combined. As we have seen in the gait generator and the note taker, it is more clear when you split the view from the plugin. So I have created `InputDeviceView` and `InputDevicePlugin` class, the `InputDeviceController` already existed. The plugin class creates the view and the controller and other plugin related stuff, then the view is only responsible for the UI buttons and layout.

## Changes
* Split `InputDevicePlugin` and `InputDeviceView`
* Rename some members that were private
* The `InputDevicecontroller.shutdown_plugin` was not used since the class was not a `Plugin`, so renamed that to `__del___`
* Fix the timer on `InputDeviceController`. The Time was 0.05 seconds, but I figured that was a bit too fast and changed it to 0.2 seconds. Furthermore, the `rospy.Duration().__init__` only accepts seconds as an integer, *not a float* (however, for some reason it still worked). 
* Added dependencies on messages

<!-- Please don't forget to request for reviews -->
