### PR TITLE
Feature/pm 391 sm to unknown button

### DIFF
--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -57,3 +57,8 @@ class InputDeviceController(object):
         rospy.logdebug('Mock Input Device published error')
         self.error_pub.publish(Error(std_msgs.msg.Header(stamp=rospy.Time.now()),
                                      'Fake error thrown by the develop input device.', Error.FATAL))
+
+    def publish_sm_to_unknown(self):
+        rospy.logdebug('Mock Input Device published state machine to unknown')
+        self.instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+                                                          GaitInstruction.UNKNOWN, ''))

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -225,11 +225,14 @@ class InputDevicePlugin(Plugin):
         error_button = self.create_button('error', image_path='/error.png',
                                           callback=lambda: self.controller.publish_error())
 
+        sm_to_unknown_button = self.create_button('force unknown',
+                                                  callback=lambda: self.controller.publish_sm_to_unknown())
+
         # The button layout.
         # Position in the array determines position on screen.
         march_button_layout = [
 
-            [home_sit, home_stand, gait_walk, gait_walk_small, gait_walk_large],
+            [home_sit, home_stand, gait_walk, gait_walk_small, gait_walk_large, sm_to_unknown_button],
 
             [gait_sit, gait_stand, rocker_switch_increment, rocker_switch_decrement, stop_button, error_button],
 


### PR DESCRIPTION

Closes PM-391
(Also use the feature/PM-391-set-state-machine-to-unknown in the march repo)

## Description
Added a button with a callback that sends the UNKNOWN tag as GaitInstruction.msg

## Changes
* new button to set the state machine to unknown
* callback of the button 