### PR TITLE
Feature: show possible gaits

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -34,4 +34,4 @@ ignore =
     W503,
     # C815: Trailing comma in Python 3.5
     C815
-ignore-names = rowCount, columnCount, headerData, setUp
+ignore-names = rowCount, columnCount, headerData, setUp, paintEvent

--- a/march_rqt_input_device/resource/input_device.ui
+++ b/march_rqt_input_device/resource/input_device.ui
@@ -83,22 +83,12 @@
       </property>
       <property name="styleSheet">
        <string notr="true">QPushButton {
-  background-color: #1F1E24;
-  color: #FFFFFF;
+  background-color: #B6BDC9;
+  color: #000000;
 }
 
-QPushButton[enabled=&quot;true&quot;] {
-  border: 3px solid rgb(67, 173, 5);
-}
-QPushButton[enabled=&quot;true&quot;]:hover {
-  border: 3px solid rgb(114, 159, 207);
-}
-QPushButton[enabled=&quot;true&quot;]:pressed {
-  border: 3px solid rgb(252, 175, 62);
-}
-
-QPushButton[enabled=&quot;false&quot;] {
-  border: 3px solid rgb(191, 64, 64);
+QPushButton:disabled {
+  background-color: #80858D;
 }</string>
       </property>
      </widget>

--- a/march_rqt_input_device/resource/input_device.ui
+++ b/march_rqt_input_device/resource/input_device.ui
@@ -18,7 +18,7 @@
     <enum>QLayout::SetMinAndMaxSize</enum>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="status_bar">
      <item>
       <widget class="QLabel" name="status_label">
        <property name="maximumSize">
@@ -52,6 +52,16 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="refresh_button">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Refreshes the buttons with possible gaits&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Refresh</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -68,7 +78,7 @@
         <x>0</x>
         <y>0</y>
         <width>870</width>
-        <height>501</height>
+        <height>493</height>
        </rect>
       </property>
       <property name="styleSheet">

--- a/march_rqt_input_device/resource/input_device.ui
+++ b/march_rqt_input_device/resource/input_device.ui
@@ -69,8 +69,11 @@
      <property name="enabled">
       <bool>true</bool>
      </property>
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="widgetResizable">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <widget class="QWidget" name="content">
       <property name="geometry">

--- a/march_rqt_input_device/resource/input_device.ui
+++ b/march_rqt_input_device/resource/input_device.ui
@@ -6,21 +6,34 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>400</height>
+    <width>890</width>
+    <height>549</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>March Input Device</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinAndMaxSize</enum>
+   </property>
+   <item>
+    <widget class="QLabel" name="status_label">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>302</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Idle</string>
+     </property>
+    </widget>
+   </item>
    <item>
     <widget class="QScrollArea" name="frame">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+     <property name="enabled">
+      <bool>true</bool>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -30,9 +43,29 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>380</width>
-        <height>380</height>
+        <width>870</width>
+        <height>503</height>
        </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">QPushButton {
+  background-color: #1F1E24;
+  color: #FFFFFF;
+}
+
+QPushButton[enabled=&quot;true&quot;] {
+  border: 3px solid rgb(67, 173, 5);
+}
+QPushButton[enabled=&quot;true&quot;]:hover {
+  border: 3px solid rgb(114, 159, 207);
+}
+QPushButton[enabled=&quot;true&quot;]:pressed {
+  border: 3px solid rgb(252, 175, 62);
+}
+
+QPushButton[enabled=&quot;false&quot;] {
+  border: 3px solid rgb(191, 64, 64);
+}</string>
       </property>
      </widget>
     </widget>

--- a/march_rqt_input_device/resource/input_device.ui
+++ b/march_rqt_input_device/resource/input_device.ui
@@ -18,17 +18,41 @@
     <enum>QLayout::SetMinAndMaxSize</enum>
    </property>
    <item>
-    <widget class="QLabel" name="status_label">
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>302</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Idle</string>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="status_label">
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>302</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Idle</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="gait_label">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QScrollArea" name="frame">
@@ -44,7 +68,7 @@
         <x>0</x>
         <y>0</y>
         <width>870</width>
-        <height>503</height>
+        <height>501</height>
        </rect>
       </property>
       <property name="styleSheet">

--- a/march_rqt_input_device/src/march_rqt_input_device/image_button.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/image_button.py
@@ -1,8 +1,8 @@
-from PyQt5.QtGui import QPainter, QPixmap
-from PyQt5.QtWidgets import QPushButton
+from PyQt5.QtGui import QColor, QPainter, QPixmap
+from PyQt5.QtWidgets import QAbstractButton
 
 
-class ImageButton(QPushButton):
+class ImageButton(QAbstractButton):
     def __init__(self, image_path):
         super(ImageButton, self).__init__()
         self._pixmap = QPixmap(image_path)
@@ -10,3 +10,6 @@ class ImageButton(QPushButton):
     def paintEvent(self, event):
         painter = QPainter(self)
         painter.drawPixmap(0, 0, self._pixmap)
+        if not self.isEnabled():
+            painter.setOpacity(0.3)
+            painter.fillRect(event.rect(), QColor(0, 0, 0))

--- a/march_rqt_input_device/src/march_rqt_input_device/image_button.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/image_button.py
@@ -1,0 +1,12 @@
+from PyQt5.QtGui import QPainter, QPixmap
+from PyQt5.QtWidgets import QPushButton
+
+
+class ImageButton(QPushButton):
+    def __init__(self, image_path):
+        super(ImageButton, self).__init__()
+        self._pixmap = QPixmap(image_path)
+
+    def paintEvent(self, event):
+        painter = QPainter(self)
+        painter.drawPixmap(0, 0, self._pixmap)

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -1,13 +1,22 @@
 import rospy
 import std_msgs.msg
 
-from march_shared_resources.msg import Error, GaitInstruction
+from march_shared_resources.msg import Error, GaitInstruction, GaitInstructionResponse
+from march_shared_resources.srv import PossibleGaits
 
 
 class InputDeviceController(object):
     def __init__(self, ping):
         self._instruction_gait_pub = rospy.Publisher('/march/input_device/instruction', GaitInstruction, queue_size=10)
+        self._instruction_response_pub = rospy.Subscriber('/march/input_device/instruction_response',
+                                                          GaitInstructionResponse, callback=self._response_callback,
+                                                          queue_size=10)
         self._error_pub = rospy.Publisher('/march/error', Error, queue_size=10)
+        self._get_possible_gaits = rospy.ServiceProxy('/march/state_machine/get_possible_gaits', PossibleGaits)
+
+        self.accepted_cb = None
+        self.finished_cb = None
+        self.rejected_cb = None
 
         self._ping = ping
 
@@ -24,8 +33,39 @@ class InputDeviceController(object):
             self._alive_timer.join()
             self._alive_pub.unregister()
 
+    def _response_callback(self, msg):
+        """
+        Callback for instruction response messages.
+
+        Calls registered callbacks when the gait is accepted, finished or rejected.
+
+        :type msg: GaitInstructionResponse
+        """
+        if msg.result == GaitInstructionResponse.GAIT_ACCEPTED:
+            if callable(self.accepted_cb):
+                self.accepted_cb()
+        elif msg.result == GaitInstructionResponse.GAIT_FINISHED:
+            if callable(self.finished_cb):
+                self.finished_cb()
+        elif msg.result == GaitInstructionResponse.GAIT_REJECTED:
+            if callable(self.rejected_cb):
+                self.rejected_cb()
+
     def _timer_callback(self, event):
         self._alive_pub.publish(event.current_real)
+
+    def get_possible_gaits(self):
+        """
+        Returns a list of names of possible gaits.
+
+        :rtype: list(str)
+        :return: List of possible gaits
+        """
+        try:
+            return self._get_possible_gaits().gaits
+        except rospy.ServiceException:
+            rospy.logwarn('Failed to contact get_possible_gaits service')
+            return []
 
     def publish_increment_step_size(self):
         rospy.logdebug('Mock Input Device published step size increment')

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_controller.py
@@ -1,5 +1,5 @@
 import rospy
-import std_msgs.msg
+from std_msgs.msg import Header, String, Time
 
 from march_shared_resources.msg import Error, GaitInstruction, GaitInstructionResponse
 from march_shared_resources.srv import PossibleGaits
@@ -11,17 +11,20 @@ class InputDeviceController(object):
         self._instruction_response_pub = rospy.Subscriber('/march/input_device/instruction_response',
                                                           GaitInstructionResponse, callback=self._response_callback,
                                                           queue_size=10)
+        self._current_gait = rospy.Subscriber('/march/gait/current', String,
+                                              callback=self._current_gait_callback, queue_size=1)
         self._error_pub = rospy.Publisher('/march/error', Error, queue_size=10)
         self._get_possible_gaits = rospy.ServiceProxy('/march/state_machine/get_possible_gaits', PossibleGaits)
 
         self.accepted_cb = None
         self.finished_cb = None
         self.rejected_cb = None
+        self.current_gait_cb = None
 
         self._ping = ping
 
         if self._ping:
-            self._alive_pub = rospy.Publisher('/march/input_device/alive', std_msgs.msg.Time, queue_size=10)
+            self._alive_pub = rospy.Publisher('/march/input_device/alive', Time, queue_size=10)
             period = rospy.Duration().from_sec(0.2)
             self._alive_timer = rospy.Timer(period, self._timer_callback)
 
@@ -51,6 +54,10 @@ class InputDeviceController(object):
             if callable(self.rejected_cb):
                 self.rejected_cb()
 
+    def _current_gait_callback(self, msg):
+        if callable(self.current_gait_cb):
+            self.current_gait_cb(msg.data)
+
     def _timer_callback(self, event):
         self._alive_pub.publish(event.current_real)
 
@@ -69,35 +76,35 @@ class InputDeviceController(object):
 
     def publish_increment_step_size(self):
         rospy.logdebug('Mock Input Device published step size increment')
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.INCREMENT_STEP_SIZE, ''))
 
     def publish_decrement_step_size(self):
         rospy.logdebug('Mock Input Device published step size decrement')
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.DECREMENT_STEP_SIZE, ''))
 
     def publish_gait(self, string):
         rospy.logdebug('Mock Input Device published gait: ' + string)
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.GAIT, string))
 
     def publish_stop(self):
         rospy.logdebug('Mock Input Device published stop')
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.STOP, ''))
 
     def publish_continue(self):
         rospy.logdebug('Mock Input Device published continue')
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.CONTINUE, ''))
 
     def publish_pause(self):
         rospy.logdebug('Mock Input Device published pause')
-        self._instruction_gait_pub.publish(GaitInstruction(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._instruction_gait_pub.publish(GaitInstruction(Header(stamp=rospy.Time.now()),
                                                            GaitInstruction.PAUSE, ''))
 
     def publish_error(self):
         rospy.logdebug('Mock Input Device published error')
-        self._error_pub.publish(Error(std_msgs.msg.Header(stamp=rospy.Time.now()),
+        self._error_pub.publish(Error(Header(stamp=rospy.Time.now()),
                                       'Fake error thrown by the develop input device.', Error.FATAL))

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -7,6 +7,8 @@ from python_qt_binding.QtWidgets import QPushButton
 from python_qt_binding.QtWidgets import QWidget
 import rospkg
 
+from .image_button import ImageButton
+
 
 class InputDeviceView(QWidget):
     def __init__(self, ui_file, controller):
@@ -323,7 +325,7 @@ class InputDeviceView(QWidget):
             self.content.style().polish(self.content)
             self.content.update()
 
-    def create_button(self, name, callback=None, image_path=None, size=(128, 160), visible=True, always_enabled=False):
+    def create_button(self, name, callback=None, image_path=None, size=(128, 160), always_enabled=False):
         """Create a push button which the mock input device can register.
 
         :param name:
@@ -334,32 +336,28 @@ class InputDeviceView(QWidget):
             The name of the image file
         :param size:
             Default size of the button
-        :param visible:
-            Turn button invisible on the gui
         :param always_enabled:
             Never disable the button if it's not in possible gaits
 
         :return:
             A QPushButton object which contains the passed arguments
         """
-        qt_button = QPushButton()
+        if image_path is None:
+            qt_button = QPushButton()
+
+            text = check_string(name)
+            qt_button.setText(text)
+        else:
+            qt_button = ImageButton(get_image_path(image_path))
+
         qt_button.setObjectName(name)
 
         if always_enabled:
             self._always_enabled_buttons.append(name)
             qt_button.setEnabled(True)
 
-        if image_path:
-            qt_button.setStyleSheet(create_image_button_css(get_image_path(image_path)))
-        else:
-            text = check_string(name)
-            qt_button.setText(text)
-
         qt_button.setMinimumSize(QSize(*size))
         qt_button.setMaximumSize(QSize(*size))
-
-        if not visible:
-            qt_button.setVisible(False)
 
         if callback:
             qt_button.clicked.connect(callback)
@@ -384,14 +382,6 @@ class InputDeviceView(QWidget):
                 qt_button_layout.addWidget(user_input_object, row, column, 1, 1)
 
         return qt_button_layout
-
-
-def create_image_button_css(img_path):
-    """CSS of a button with a background-image."""
-    css_base = """
-    background: url(<img_path>) no-repeat center;
-    """
-    return css_base.replace('<img_path>', img_path)
 
 
 def get_image_path(img_name):

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -303,6 +303,8 @@ class InputDeviceView(QWidget):
         self.gait_label.setText(gait_name)
 
     def _update_possible_gaits(self):
+        self.frame.setEnabled(False)
+        self.frame.verticalScrollBar().setEnabled(False)
         possible_gaits = self._controller.get_possible_gaits()
         layout = self.content.layout()
         if layout:
@@ -316,15 +318,8 @@ class InputDeviceView(QWidget):
                     button.setEnabled(True)
                 else:
                     button.setEnabled(False)
-
-                # The following is necessary for updating the stylesheet
-                button.style().unpolish(button)
-                button.style().polish(button)
-                button.update()
-
-            self.content.style().unpolish(self.content)
-            self.content.style().polish(self.content)
-            self.content.update()
+        self.frame.setEnabled(True)
+        self.frame.verticalScrollBar().setEnabled(True)
 
     def create_button(self, name, callback=None, image_path=None, size=(128, 160), always_enabled=False):
         """Create a push button which the mock input device can register.

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -30,6 +30,8 @@ class InputDeviceView(QWidget):
         # Extend the widget with all attributes and children from UI file
         loadUi(ui_file, self)
 
+        self.refresh_button.clicked.connect(self._update_possible_gaits)
+
         self._create_buttons()
         self._update_possible_gaits()
 

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -300,10 +300,14 @@ class InputDeviceView(QWidget):
                 else:
                     button.setEnabled(False)
 
-                # The following is necessary for updating the button's stylesheet
+                # The following is necessary for updating the stylesheet
                 button.style().unpolish(button)
                 button.style().polish(button)
                 button.update()
+
+            self.content.style().unpolish(self.content)
+            self.content.style().polish(self.content)
+            self.content.update()
 
     def create_button(self, name, callback=None, image_path=None, size=(128, 160), visible=True, always_enabled=False):
         """Create a push button which the mock input device can register.

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -23,6 +23,7 @@ class InputDeviceView(QWidget):
         self._controller.accepted_cb = self._accepted_cb
         self._controller.finished_cb = self._finished_cb
         self._controller.rejected_cb = self._rejected_cb
+        self._controller.current_gait_cb = self._current_gait_cb
 
         # Extend the widget with all attributes and children from UI file
         loadUi(ui_file, self)
@@ -263,11 +264,16 @@ class InputDeviceView(QWidget):
 
     def _finished_cb(self):
         self.status_label.setText('Gait finished')
+        self.gait_label.setText('')
         self._update_possible_gaits()
 
     def _rejected_cb(self):
         self.status_label.setText('Gait rejected')
+        self.gait_label.setText('')
         self._update_possible_gaits()
+
+    def _current_gait_cb(self, gait_name):
+        self.gait_label.setText(gait_name)
 
     def _update_possible_gaits(self):
         possible_gaits = self._controller.get_possible_gaits()

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -366,25 +366,11 @@ def get_image_path(img_name):
 
 
 def check_string(text):
-    """Split text into two lines if sentence is to long.
+    """Split text into new lines on every third word.
 
-    :param text:
-        The text to split in half.
-
-    :return:
-        New string which contains of an enter in the middle.
+    :type text: str
+    :param text: The text to split
+    :return New string which contains newlines
     """
-    text = text.replace('_', ' ')
-    split_text = text.split(' ')
-    if len(split_text) >= 3:
-
-        new_string = ''
-        middle = len(split_text) / 2
-
-        new_string += ' '.join(split_text[:middle])
-        new_string += '\n'
-        new_string += ' '.join(split_text[middle:])
-        return new_string
-
-    else:
-        return text
+    words = enumerate(text.replace('_', ' ').split(' '))
+    return reduce(lambda acc, (i, x): acc + '\n' + x if i % 3 == 0 else acc + ' ' + x, words, '')[1:]

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -286,7 +286,7 @@ class InputDeviceView(QWidget):
                 button.update()
 
     @staticmethod
-    def create_button(text, callback=None, image_path=None, size=(125, 150), visible=True):
+    def create_button(text, callback=None, image_path=None, size=(128, 160), visible=True):
         """Create a push button which the mock input device can register.
 
         :param text:
@@ -346,9 +346,7 @@ class InputDeviceView(QWidget):
 def create_image_button_css(img_path):
     """CSS of a button with a background-image."""
     css_base = """
-    background: url(<img_path>) no-repeat center center;
-    background-color:#1F1E24;
-    color: #000000;
+    background: url(<img_path>) no-repeat center;
     """
     return css_base.replace('<img_path>', img_path)
 

--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -287,6 +287,7 @@ class InputDeviceView(QWidget):
 
     def _accepted_cb(self):
         self.status_label.setText('Gait accepted')
+        self._update_possible_gaits()
 
     def _finished_cb(self):
         self.status_label.setText('Gait finished')


### PR DESCRIPTION
Closes PM-392

## Description
This PR introduces showing which gaits are possible to be executed, a gait process status and showing the current gait. The gaits that can be currently executed are indicated with a green border and others with a red border. The style of the buttons gets updated when a gait has been finished or can be updated manually with the refresh button. Some non-gait buttons, like stop and pause, are always enabled.

_Small note:_ I still sometimes get errors that a stylesheet could not be parsed and very rarely the the input device just shuts down, with no kind of stack trace. So if you get this, describe what you did, so I can try to reproduce it. To me it seemed random.
 
## Changes
* Add status bar that shows current gait status, current gait and a _Refresh_ button
* Add stylesheet to _ui_ file for enabled and disabled buttons
* Fix `check_string` method to split on every third word to avoid to long lines in a button