### PR TITLE
Feature: imotioncube diagnostics

### DIFF
--- a/march_rqt_robot_monitor/CMakeLists.txt
+++ b/march_rqt_robot_monitor/CMakeLists.txt
@@ -4,12 +4,14 @@ project(march_rqt_robot_monitor)
 find_package(catkin REQUIRED COMPONENTS
     diagnostic_aggregator
     diagnostic_updater
+    march_shared_resources
     std_msgs
 )
 
 catkin_package(CATKIN_DEPENDS
     diagnostic_aggregator
     diagnostic_updater
+    march_shared_resources
     std_msgs
 )
 

--- a/march_rqt_robot_monitor/config/analyzers.yaml
+++ b/march_rqt_robot_monitor/config/analyzers.yaml
@@ -20,4 +20,4 @@ analyzers:
     type: diagnostic_aggregator/GenericAnalyzer
     path: iMotioncubes
     contains: 'IMC'
-    remove_prefix: 'march_rqt_robot_monitor: '
+    remove_prefix: 'march_rqt_robot_monitor_node: IMC '

--- a/march_rqt_robot_monitor/config/analyzers.yaml
+++ b/march_rqt_robot_monitor/config/analyzers.yaml
@@ -5,11 +5,19 @@ analyzers:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Temperatures
     contains: 'Temperature'
+    remove_prefix: 'march_rqt_robot_monitor_node: '
   inputs:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Inputs
     contains: 'input_device'
+    remove_prefix: 'march_rqt_robot_monitor_node: '
   control:
     type: diagnostic_aggregator/GenericAnalyzer
     path: Control
     contains: 'Control'
+    remove_prefix: 'march_rqt_robot_monitor_node: '
+  imotioncubes:
+    type: diagnostic_aggregator/GenericAnalyzer
+    path: iMotioncubes
+    contains: 'IMC'
+    remove_prefix: 'march_rqt_robot_monitor: '

--- a/march_rqt_robot_monitor/package.xml
+++ b/march_rqt_robot_monitor/package.xml
@@ -12,6 +12,7 @@
   <depend>std_msgs</depend>
   <depend>diagnostic_aggregator</depend>
   <depend>diagnostic_updater</depend>
+  <depend>march_shared_resources</depend>
 
   <exec_depend>roscpp</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/control.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/control.py
@@ -47,7 +47,8 @@ class CheckJointValues(object):
     def position_diagnostics(self, stat):
         """The diagnostic message to display the positions in standard format."""
         if self._timestamp is None:
-            stat.add(' Topic error ', 'No events recorded.')
+            stat.add('Topic error', 'No events recorded')
+            stat.summary(DiagnosticStatus.STALE, 'No position recorded')
             return stat
 
         stat.add('Timestamp', self._timestamp)
@@ -83,7 +84,8 @@ class CheckJointValues(object):
     def velocity_diagnostics(self, stat):
         """The diagnostic message to display the velocities in standard format."""
         if self._timestamp is None:
-            stat.add(' Topic error ', 'No events recorded.')
+            stat.add('Topic error', 'No events recorded')
+            stat.summary(DiagnosticStatus.STALE, 'No velocity recorded')
             return stat
 
         stat.add('Timestamp', self._timestamp)
@@ -114,7 +116,8 @@ class CheckJointValues(object):
     def effort_diagnostics(self, stat):
         """The diagnostic message to display the efforts in standard format."""
         if self._timestamp is None:
-            stat.add(' Topic error ', 'No events recorded.')
+            stat.add('Topic error', 'No events recorded')
+            stat.summary(DiagnosticStatus.STALE, 'No effort recorded')
             return stat
 
         stat.add('Timestamp', self._timestamp)

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/imc_state.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/imc_state.py
@@ -1,0 +1,59 @@
+from diagnostic_msgs.msg import DiagnosticStatus
+import rospy
+
+from march_shared_resources.msg import ImcState
+
+
+class CheckImcStatus:
+    def __init__(self, updater):
+        """Initializes an IMC diagnostic which analyzes IMC states.
+
+        :type updater: diagnostic_updater.Updater
+        """
+        self._updater = updater
+        self._sub = rospy.Subscriber('/march/imc_states', ImcState, self._cb)
+        self._imc_state = None
+
+        self._diagnostics = set()
+
+    def _cb(self, msg):
+        """Callback for imc_states.
+
+        :type msg: ImcState
+        """
+        self._imc_state = msg
+        for i in range(len(msg.joint_names)):
+            joint_name = msg.joint_names[i]
+            if joint_name not in self._diagnostics:
+                self._diagnostics.add(joint_name)
+                self._updater.add('IMC {0}'.format(joint_name), self._diagnostic(i))
+
+    def _diagnostic(self, index):
+        """Creates a diagnostic function for an IMC.
+
+        :type index: int
+        :param index: index of the joint
+        :return Curried diagnostic function that updates the diagnostic status
+                according to the given index
+        """
+        def d(stat):
+            if self._imc_state.joint_names[index] is None:
+                stat.summary(DiagnosticStatus.STALE, 'No more events recorded')
+                return stat
+            detailed_error = int(self._imc_state.detailed_error[index])
+            motion_error = int(self._imc_state.motion_error[index])
+            state = self._imc_state.state[index]
+
+            stat.add('Status word', self._imc_state.status_word[index])
+            if detailed_error != 0 or motion_error != 0:
+                stat.add('Detailed error', self._imc_state.detailed_error[index])
+                stat.add('Detailed error description', self._imc_state.detailed_error_description[index])
+                stat.add('Motion error', self._imc_state.motion_error[index])
+                stat.add('Motion error description', self._imc_state.motion_error_description[index])
+                stat.summary(DiagnosticStatus.ERROR, state)
+            else:
+                stat.summary(DiagnosticStatus.OK, state)
+
+            return stat
+
+        return d

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/temperature.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/temperature.py
@@ -33,7 +33,8 @@ class CheckJointTemperature(object):
     def diagnostics(self, stat):
         """The diagnostic message to display in the standard stat format."""
         if self._timestamp is None:
-            stat.add(' Topic error ', 'No events recorded.')
+            stat.add('Topic error', 'No events recorded')
+            stat.summary(DiagnosticStatus.STALE, 'No temperature recorded')
             return stat
 
         if not LOWER_THRESHOLD_VALID_TEMPERATURE_VALUE < self._temperature < UPPER_THRESHOLD_VALID_TEMPERATURE_VALUE:

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/temperature.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/temperature.py
@@ -54,3 +54,5 @@ class CheckJointTemperature(object):
             stat.summary(DiagnosticStatus.WARN, 'Temperature almost too high ({tp}).'.format(tp=self._temperature))
         else:
             stat.summary(DiagnosticStatus.ERROR, 'Temperature to high ({tp}).'.format(tp=self._temperature))
+
+        return stat

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/updater.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/updater.py
@@ -4,6 +4,7 @@ from sensor_msgs.msg import JointState, Temperature
 from std_msgs.msg import Time
 
 from .diagnostic_analyzers.control import CheckJointValues
+from .diagnostic_analyzers.imc_state import CheckImcStatus
 from .diagnostic_analyzers.temperature import CheckJointTemperature
 from .diagnostic_analyzers.topic_frequency import CheckTopicFrequency
 
@@ -55,6 +56,8 @@ def main():
     updater.add('Control position values', check_current_movement_values.position_diagnostics)
     updater.add('Control velocity values', check_current_movement_values.velocity_diagnostics)
     updater.add('Control effort values', check_current_movement_values.effort_diagnostics)
+
+    CheckImcStatus(updater)
 
     updater.force_update()
 

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/updater.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/updater.py
@@ -1,4 +1,3 @@
-
 import diagnostic_updater
 import rospy
 from sensor_msgs.msg import JointState, Temperature
@@ -11,7 +10,6 @@ from .diagnostic_analyzers.topic_frequency import CheckTopicFrequency
 
 def main():
     rospy.init_node('Diagnostic_updater')
-    temperature = False
 
     updater = diagnostic_updater.Updater()
     updater.setHardwareID('MARCH IVc')
@@ -20,38 +18,37 @@ def main():
     CheckTopicFrequency('Input_Device', '/march/input_device/alive', Time, updater, 5)
 
     # Temperature checks
-    if temperature:
-        check_temp_joint_left_ankle = \
-            CheckJointTemperature('Temperature left ankle', '/march/temperature/left_ankle', Temperature)
-        updater.add('Temperature left ankle', check_temp_joint_left_ankle.diagnostics)
+    check_temp_joint_left_ankle = \
+        CheckJointTemperature('Temperature left ankle', '/march/temperature/left_ankle', Temperature)
+    updater.add('Temperature left ankle', check_temp_joint_left_ankle.diagnostics)
 
-        check_temp_joint_left_knee = \
-            CheckJointTemperature('Temperature left knee', '/march/temperature/left_knee', Temperature)
-        updater.add('Temperature left knee', check_temp_joint_left_knee.diagnostics)
+    check_temp_joint_left_knee = \
+        CheckJointTemperature('Temperature left knee', '/march/temperature/left_knee', Temperature)
+    updater.add('Temperature left knee', check_temp_joint_left_knee.diagnostics)
 
-        check_temp_joint_left_hip_fe = \
-            CheckJointTemperature('Temperature left hip FE', '/march/temperature/left_hip_fe', Temperature)
-        updater.add('Temperature left hip FE', check_temp_joint_left_hip_fe.diagnostics)
+    check_temp_joint_left_hip_fe = \
+        CheckJointTemperature('Temperature left hip FE', '/march/temperature/left_hip_fe', Temperature)
+    updater.add('Temperature left hip FE', check_temp_joint_left_hip_fe.diagnostics)
 
-        check_temp_joint_left_hip_aa = \
-            CheckJointTemperature('Temperature left hip AA', '/march/temperature/left_hip_aa', Temperature)
-        updater.add('Temperature left hip AA', check_temp_joint_left_hip_aa.diagnostics)
+    check_temp_joint_left_hip_aa = \
+        CheckJointTemperature('Temperature left hip AA', '/march/temperature/left_hip_aa', Temperature)
+    updater.add('Temperature left hip AA', check_temp_joint_left_hip_aa.diagnostics)
 
-        check_temp_joint_right_ankle = \
-            CheckJointTemperature('Temperature right ankle', '/march/temperature/right_ankle', Temperature)
-        updater.add('Temperature right ankle', check_temp_joint_right_ankle.diagnostics)
+    check_temp_joint_right_ankle = \
+        CheckJointTemperature('Temperature right ankle', '/march/temperature/right_ankle', Temperature)
+    updater.add('Temperature right ankle', check_temp_joint_right_ankle.diagnostics)
 
-        check_temp_joint_right_knee = \
-            CheckJointTemperature('Temperature right knee', '/march/temperature/right_knee', Temperature)
-        updater.add('Temperature right knee', check_temp_joint_right_knee.diagnostics)
+    check_temp_joint_right_knee = \
+        CheckJointTemperature('Temperature right knee', '/march/temperature/right_knee', Temperature)
+    updater.add('Temperature right knee', check_temp_joint_right_knee.diagnostics)
 
-        check_temp_joint_right_hip_fe = \
-            CheckJointTemperature('Temperature right hip FE', '/march/temperature/right_hip_fe', Temperature)
-        updater.add('Temperature right hip FE', check_temp_joint_right_hip_fe.diagnostics)
+    check_temp_joint_right_hip_fe = \
+        CheckJointTemperature('Temperature right hip FE', '/march/temperature/right_hip_fe', Temperature)
+    updater.add('Temperature right hip FE', check_temp_joint_right_hip_fe.diagnostics)
 
-        check_temp_joint_right_hip_aa = \
-            CheckJointTemperature('Temperature right hip AA', '/march/temperature/right_hip_aa', Temperature)
-        updater.add('Temperature right hip AA', check_temp_joint_right_hip_aa.diagnostics)
+    check_temp_joint_right_hip_aa = \
+        CheckJointTemperature('Temperature right hip AA', '/march/temperature/right_hip_aa', Temperature)
+    updater.add('Temperature right hip AA', check_temp_joint_right_hip_aa.diagnostics)
 
     # control checks
     check_current_movement_values = CheckJointValues('march/joint_states', JointState)


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-434

## Description
This PR adds a iMotioncube state diagnostic. It adds an `iMotioncubes` entry with every IMC as a child with a status. The status is OK when they all are in _Operation Enabled_ and ERROR otherwise.

![image](https://user-images.githubusercontent.com/23523462/82546425-5b55d300-9b58-11ea-9895-c686fd9c9321.png)

![image](https://user-images.githubusercontent.com/23523462/82546512-7c1e2880-9b58-11ea-903e-33db2832757e.png)

Furthermore, I have also found a way to remove the prefixes from the status entries, so now the names are shorter and more readable.

## Changes
* Add `CheckImcStatus` diagnostic which listens to `/march/imc_states` and adds a diagnostic for every IMC
* Remove node prefixes from analyzers
* Change diagnostic status to `STALE`, when no events have been recorded


<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
