### PR TITLE
Feature: add gait version service

### DIFF
--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_controller.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_controller.py
@@ -1,55 +1,53 @@
-
 import ast
-import sys
 
 import rospy
+from std_srvs.srv import Trigger
 
-from march_shared_resources.srv import StringTrigger, Trigger
+from march_shared_resources.srv import SetGaitVersion
 
 
 class GaitSelectionController(object):
     def __init__(self):
         """Base class to communicate with the gait selection node."""
-        try:
-            rospy.wait_for_service('/march/gait_selection/get_version_map', 3)
-            rospy.wait_for_service('/march/gait_selection/get_directory_structure', 3)
-            rospy.wait_for_service('/march/gait_selection/set_version_map', 3)
-            rospy.wait_for_service('/march/gait_selection/update_default_versions', 3)
-        except rospy.ROSException:
-            rospy.logerr('Shutting down march_rqt_gait_selection, could not connect to march_gait_selection.')
-            rospy.signal_shutdown('Shutting down march_rqt_gait_selection, could not connect to march_gait_selection.')
-            sys.exit(0)
-
         self._get_version_map = rospy.ServiceProxy('/march/gait_selection/get_version_map', Trigger)
         self._get_directory_structure = rospy.ServiceProxy('/march/gait_selection/get_directory_structure', Trigger)
 
-        self._set_version_map = rospy.ServiceProxy('/march/gait_selection/set_version_map', StringTrigger)
+        self._set_gait_version = rospy.ServiceProxy('/march/gait_selection/set_gait_version', SetGaitVersion)
         self._set_default_versions = rospy.ServiceProxy('/march/gait_selection/update_default_versions', Trigger)
 
     def get_version_map(self):
         """Get the gait version map used in the gait selection node."""
         try:
             return dict(ast.literal_eval(self._get_version_map().message))
-        except ValueError:
-            return None
+        except (ValueError, rospy.ServiceException):
+            return dict()
 
     def get_directory_structure(self):
         """Get the gait directory of the selected gait_directory in the gait selection node."""
         try:
             return dict(ast.literal_eval(self._get_directory_structure().message))
-        except ValueError:
-            return None
+        except (ValueError, rospy.ServiceException):
+            return dict()
 
-    def set_version_map(self, gait_version_map):
+    def set_gait_version(self, gait_name, subgait_names, versions):
         """Set a new gait version map to use in the gait selection node.
 
-        :param gait_version_map:
-            The new gait version map as dictionary to parse to the gait selection node
+        :param str gait_name: The name of the gait
+        :param list(str) subgait_names: Names of subgaits of which to change the version
+        :param list(str) versions: Names of the versions
         """
-        result = self._set_version_map(str(gait_version_map))
-        return result.success
+        try:
+            result = self._set_gait_version(gait_name, subgait_names, versions)
+            if result.message:
+                rospy.logwarn(result.message)
+            return result.success
+        except rospy.ServiceException:
+            return False
 
     def set_default_versions(self):
         """Save the current gait version map in the gait selection node as a default."""
-        result = self._set_default_versions()
-        return result.success
+        try:
+            result = self._set_default_versions()
+            return result.success
+        except rospy.ServiceException:
+            return False

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_controller.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_controller.py
@@ -5,6 +5,8 @@ from std_srvs.srv import Trigger
 
 from march_shared_resources.srv import SetGaitVersion
 
+from .gait_selection_errors import GaitServiceError, InvalidResponseError
+
 
 class GaitSelectionController(object):
     def __init__(self):
@@ -19,15 +21,19 @@ class GaitSelectionController(object):
         """Get the gait version map used in the gait selection node."""
         try:
             return dict(ast.literal_eval(self._get_version_map().message))
-        except (ValueError, rospy.ServiceException):
-            return dict()
+        except ValueError:
+            raise InvalidResponseError
+        except rospy.ServiceException:
+            raise GaitServiceError
 
     def get_directory_structure(self):
         """Get the gait directory of the selected gait_directory in the gait selection node."""
         try:
             return dict(ast.literal_eval(self._get_directory_structure().message))
-        except (ValueError, rospy.ServiceException):
-            return dict()
+        except ValueError:
+            raise InvalidResponseError
+        except rospy.ServiceException:
+            raise GaitServiceError
 
     def set_gait_version(self, gait_name, subgait_names, versions):
         """Set a new gait version map to use in the gait selection node.
@@ -38,16 +44,14 @@ class GaitSelectionController(object):
         """
         try:
             result = self._set_gait_version(gait_name, subgait_names, versions)
-            if result.message:
-                rospy.logwarn(result.message)
-            return result.success
+            return result.success, result.message
         except rospy.ServiceException:
-            return False
+            raise GaitServiceError
 
     def set_default_versions(self):
         """Save the current gait version map in the gait selection node as a default."""
         try:
             result = self._set_default_versions()
-            return result.success
+            return result.success, result.message
         except rospy.ServiceException:
-            return False
+            raise GaitServiceError

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_errors.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_errors.py
@@ -1,0 +1,13 @@
+class GaitSelectionError(Exception):
+    def __init__(self, msg):
+        super(GaitSelectionError, self).__init__(msg)
+
+
+class InvalidResponseError(GaitSelectionError):
+    def __init__(self):
+        super(InvalidResponseError, self).__init__('Failed to parse response')
+
+
+class GaitServiceError(GaitSelectionError):
+    def __init__(self):
+        super(GaitServiceError, self).__init__('Failed to contact gait selection')

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -3,6 +3,7 @@ from PyQt5.QtWidgets import QWidget
 from python_qt_binding import loadUi
 import rospy
 
+from .gait_selection_errors import GaitSelectionError
 from .gait_selection_pop_up import PopUpWindow
 
 
@@ -134,13 +135,17 @@ class GaitSelectionView(QWidget):
         self._is_refresh_active = True
         self._clear_gui(clear_gait_menu=True)
 
-        self.available_gaits = self._controller.get_directory_structure()
-        self.version_map = self._controller.get_version_map()
+        try:
+            self.available_gaits = self._controller.get_directory_structure()
+            self.version_map = self._controller.get_version_map()
 
-        self._gait_menu.addItems(sorted(self.available_gaits.keys()))
+            self._gait_menu.addItems(sorted(self.available_gaits.keys()))
 
-        self._log('Directory data refreshed', 'success')
-        self._is_refresh_active = False
+            self._log('Directory data refreshed', 'success')
+        except GaitSelectionError as e:
+            self._log(str(e), 'error')
+        finally:
+            self._is_refresh_active = False
 
     # logger
     def _log(self, msg, color_tag='info'):
@@ -179,10 +184,14 @@ class GaitSelectionView(QWidget):
 
     def _save_default(self):
         """Save the currently selected subgait versions as default values."""
-        if self._controller.set_default_versions():
-            self._log('Set new default versions', 'success')
-        else:
-            self._log('Set new default versions failed', 'error')
+        try:
+            success, msg = self._controller.set_default_versions()
+            if success:
+                self._log(msg if msg else 'Set new default versions', 'success')
+            else:
+                self._log(msg if msg else 'Failed to set default versions', 'error')
+        except GaitSelectionError as e:
+            self._log(str(e), 'error')
 
     def _apply(self):
         """Apply newly selected subgait versions to the gait selection node."""
@@ -195,16 +204,24 @@ class GaitSelectionView(QWidget):
                 subgait_names.append(subgait_label.text())
                 versions.append(subgait_menu.currentText())
 
-        if self._controller.set_gait_version(gait_name, subgait_names, versions):
-            self._log('Version change applied', 'success')
-        else:
-            self._log('Version change applied failed', 'failed')
+        try:
+            success, msg = self._controller.set_gait_version(gait_name, subgait_names, versions)
+            if success:
+                self._log(msg if msg else 'Version change applied', 'success')
+            else:
+                self._log(msg if msg else 'Version change applied failed', 'failed')
+        except GaitSelectionError as e:
+            self._log(str(e), 'error')
 
     def _show_version_map_pop_up(self):
         """Use a pop up window to display all the gait, subgaits and currently used versions."""
-        version_map = self._controller.get_version_map()
-        version_map_string = ''
+        try:
+            version_map = self._controller.get_version_map()
+        except GaitSelectionError as e:
+            self._log(str(e), 'error')
+            return
 
+        version_map_string = ''
         for gait_name in sorted(version_map.keys()):
             version_map_string += '{gait} \n'.format(gait=gait_name)
             for subgait_name, version in version_map[gait_name].items():

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -74,7 +74,7 @@ class GaitSelectionView(QWidget):
         self._clear_gui()
 
         gait_name = self._gait_menu.currentText()
-        subgaits = self.available_gaits[gait_name]['subgaits']
+        subgaits = self.available_gaits[gait_name]
 
         latest_used_index = 0
         for index, (subgait_name, versions) in enumerate(subgaits.items()):
@@ -111,18 +111,6 @@ class GaitSelectionView(QWidget):
             self._subgait_menus[unused_index].setDisabled(1)
 
         self._is_update_active = False
-
-    def update_selected_versions(self):
-        """Read the subgait version menus and save the newly selected versions to the local version map."""
-        gait_name = self._gait_menu.currentText()
-
-        for subgait_label, subgait_menu in zip(self._subgait_labels, self._subgait_menus):
-            subgait_name = subgait_label.text()
-            if subgait_name != 'Unused':
-                try:
-                    self.version_map[gait_name][subgait_name] = subgait_menu.currentText()
-                except KeyError:
-                    pass
 
     def update_version_colors(self):
         """Update the subgait labels with a specific color to represent a change in version."""
@@ -198,8 +186,16 @@ class GaitSelectionView(QWidget):
 
     def _apply(self):
         """Apply newly selected subgait versions to the gait selection node."""
-        self.update_selected_versions()
-        if self._controller.set_version_map(self.version_map):
+        gait_name = self._gait_menu.currentText()
+        subgait_names = []
+        versions = []
+
+        for subgait_label, subgait_menu in zip(self._subgait_labels, self._subgait_menus):
+            if subgait_label.text() != 'Unused':
+                subgait_names.append(subgait_label.text())
+                versions.append(subgait_menu.currentText())
+
+        if self._controller.set_gait_version(gait_name, subgait_names, versions):
             self._log('Version change applied', 'success')
         else:
             self._log('Version change applied failed', 'failed')


### PR DESCRIPTION
Closes PM-445

## Description
Implemented the new gait version service from project-march/march#541. Furthermore, I have changed the way error handling is done in using the gait selection service. It no longer waits for the services to be available, so that RQT can be launched before the gait selection server is online. It also logs the errors it receives from the gait selection services.

## Changes
* Implement set gait version service
* Add `GaitSelectionError` and derivatives
* Catch exceptions from service calls
* Remove wait for service

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
