### PR TITLE
Fix/sorting of versions above 9 in gait selection

### DIFF
--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -95,7 +95,7 @@ class GaitSelectionView(QWidget):
             """
             try:
                 length = len(version)
-                version_number = ''.join(letter for letter in version[length - 2: length] if letter.isdigit())
+                version_number = ''.join(char for char in version[length - 2: length] if char.isdigit())
                 return int(version_number)
             except ValueError:
                 return version

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -88,6 +88,19 @@ class GaitSelectionView(QWidget):
 
     def update_version_menus(self):
         """When a gait is selected set the subgait labels and populate the subgait menus with the available versions."""
+
+        def version_sorter(version):
+            """Used in the sort function to sort numbers which are 9<
+
+            :param version: str of the version
+            """
+            try:
+                length = len(version)
+                version_number = ''.join(letter for letter in version[length-2: length] if letter.isdigit())
+                return int(version_number)
+            except ValueError:
+                return version
+
         self._is_update_active = True
         if self._is_refresh_active:
             return
@@ -111,7 +124,7 @@ class GaitSelectionView(QWidget):
             subgait_label.show()
 
             subgait_label.setText(subgait_name)
-            subgait_menu.addItems(versions)
+            subgait_menu.addItems(sorted(versions, key=version_sorter))
 
             try:
                 current_version = self.version_map[gait_name][subgait_name]

--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -88,15 +88,14 @@ class GaitSelectionView(QWidget):
 
     def update_version_menus(self):
         """When a gait is selected set the subgait labels and populate the subgait menus with the available versions."""
-
         def version_sorter(version):
-            """Used in the sort function to sort numbers which are 9<
+            """Used in the sort function to sort numbers which are 9<.
 
             :param version: str of the version
             """
             try:
                 length = len(version)
-                version_number = ''.join(letter for letter in version[length-2: length] if letter.isdigit())
+                version_number = ''.join(letter for letter in version[length - 2: length] if letter.isdigit())
                 return int(version_number)
             except ValueError:
                 return version


### PR DESCRIPTION

## Description
during a groundgait session I discovered that subgait version above the 9 (e.g. 10, 11, 12, 13) were scaled under the 1. So the subgait menu would look like; [1, 10, 11, 12, 2, 3, 4, 5, 6]. This was kind off confusing and I found out that the `sorted()` function inside python did not satisfy the needed sort. Therefore I created a generator to add to the `sorted()` function. 

## Changes
* Created a generator to extract possible version number from the .subgait file
* Sorted the subgaits before adding them to the menu. 