### PR TITLE
The current subgait version index was derived from the old version list

### DIFF
--- a/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
+++ b/march_rqt_gait_selection/src/march_rqt_gait_selection/gait_selection_view.py
@@ -122,8 +122,10 @@ class GaitSelectionView(QWidget):
             subgait_menu.show()
             subgait_label.show()
 
+            versions = sorted(versions, key=version_sorter)
+
             subgait_label.setText(subgait_name)
-            subgait_menu.addItems(sorted(versions, key=version_sorter))
+            subgait_menu.addItems(versions)
 
             try:
                 current_version = self.version_map[gait_name][subgait_name]


### PR DESCRIPTION

## Description
The new version sorter changed the subgait version list order but this was only applied in the dropdown menu and not for the current index calculation. So the current subgait index would still be derived from the old subgait version list, this could sometimes mess up the current subgait.
 
## Changes
* Updated the new versions list to be applied everywhere