### PR TITLE
remove max frequency for ipd monitor

### DIFF
--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/check_input_device.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/check_input_device.py
@@ -6,7 +6,7 @@ class CheckInputDevice(object):
     """Base class to diagnose whether the input devices are connected properly."""
 
     def __init__(self, topic, message_type, updater, frequency):
-        self._frequency_params = FrequencyStatusParam({'min': frequency, 'max': frequency}, 0.1, 10)
+        self._frequency_params = FrequencyStatusParam({'min': frequency}, 0.1)
         self._updater = updater
         self._diagnostics = {}
 


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->



## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->
It think it doesn't make sense to have a max for a ipd frequency, because it gives a warning when an ipd is too good connected. Especially with the different frequencies for the rqt and crutch ipd this gives unnecessary warnings. 
## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
Removed the max for the ipd frequency in the robot monitor. 
## Testing
Start the stimulation with this branch en check and launch the rqt robot monitor. 
<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
