### PR TITLE
removed unecessary force update in robot monitor updater

### DIFF
--- a/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
+++ b/march_rqt_input_device/src/march_rqt_input_device/input_device_view.py
@@ -93,6 +93,10 @@ class InputDeviceView(QWidget):
             self.create_button('gait_single_step_normal', image_path='/gait_single_step_medium.png',
                                callback=lambda: self._controller.publish_gait('gait_single_step_normal'))
 
+        gait_test_left_right = \
+            self.create_button('gait_test_left_right',
+                               callback=lambda: self._controller.publish_gait('gait_test_left_right'))
+
         gait_side_step_left = \
             self.create_button('gait_side_step_left', image_path='/gait_side_step_left.png',
                                callback=lambda: self._controller.publish_gait('gait_side_step_left'))
@@ -275,7 +279,8 @@ class InputDeviceView(QWidget):
             [gait_sofa_sit, gait_sofa_stand, gait_single_step_normal, gait_single_step_small, continue_button,
              pause_button],
 
-            [gait_stairs_up, gait_stairs_down, gait_stairs_up_single_step, gait_stairs_down_single_step],
+            [gait_stairs_up, gait_stairs_down, gait_stairs_up_single_step, gait_stairs_down_single_step,
+             gait_test_left_right],
 
             [gait_side_step_left, gait_side_step_right, gait_side_step_left_small, gait_side_step_right_small],
 

--- a/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/check_input_device.py
+++ b/march_rqt_robot_monitor/src/march_rqt_robot_monitor/diagnostic_analyzers/check_input_device.py
@@ -24,4 +24,4 @@ class CheckInputDevice(object):
         else:
             self._diagnostics[msg.id] = HeaderlessTopicDiagnostic('input_device {0}'.format(msg.id),
                                                                   self._updater, self._frequency_params)
-            self._updater.force_update()
+


### PR DESCRIPTION
<!--
To streamline the process of creating and reviewing pull requests, we have created a template.
It is not required to follow this template perfectly, but we encourage you to think about each header.
Before you publish a pull request think about the definition of done for the issue you are trying to resolve.
-->

<!--
Provide the key for the Jira issue this PR resolves.
-->

Closes PM-513

## Description
<!--
Provide a concise description on the feature/fix your pull request implements.
-->

Launching the monitor before the simulation / exo no longer gives a zero division error.

## Changes
<!--
Provide a list of important changes.

e.g.
* Added tests
* Renamed variable
* Added topic
-->
self._updater.force_update() removed from check_input_device. This force_update is unnecessary as updater already force updates.

## Testing

<!-- Provide additional information necessary for testing this PR. This includes details like branches in other repos, launch arguments or gait directories. In the case of a bug fix, provide the steps to reproduce the bug.-->

<!-- Reviews are automatically requested after the pull request has been created. Only request for a review if you want a specific person to review your changes.-->
